### PR TITLE
Use brew in homebrew_install_path/bin instead of system PATH.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,21 +19,21 @@
   when: homebrew_binary.stat.exists == false
 
 - name: Get list of installed homebrew packages.
-  command: brew list
+  command: "{{ homebrew_install_path }}/bin/brew list"
   register: homebrew_list
   changed_when: false
 
 - name: Install configured homebrew packages.
-  command: "brew install {{ item }}"
+  command: "{{ homebrew_install_path }}/bin/brew install {{ item }}"
   with_items: homebrew_installed_packages
   when: "'{{ item }}' not in homebrew_list.stdout"
 
 - name: Get list of tapped homebrew taps.
-  command: brew tap
+  command: "{{ homebrew_install_path }}/bin/brew tap"
   register: homebrew_tap_list
   changed_when: false
 
 - name: Tap configured homebrew taps.
-  command: "brew tap {{ item }}"
+  command: "{{ homebrew_install_path }}/bin/brew tap {{ item }}"
   with_items: homebrew_taps
   when: "'{{ item }}' not in homebrew_tap_list.stdout"


### PR DESCRIPTION
Instead of using a brew that's available in system PATH, it's safer to use the one specified in homebrew_install_path/bin instead. This solves 3 scenarios:
- PATH already has a different brew that preceded the one in non-default homebrew_install_path/bin
- Using default homebrew_install_path /usr/local/, but /usr/local/bin is not available in system PATH by default
- Using non-default homebrew_install_path, with the symlink to /usr/local (as documented on README), but neither that path nor /usr/local/bin is available in system PATH

The second scenario was the problem I encountered on my Mac Mini.
I could modify the system PATH in ~/.bashrc, but I think it's more user-friendly if ansible-role-homebrew uses homebrew_install_path. It takes care of the 3 scenarios above, still compatible with the existing behaviour, and users don't have to worry about modifying system PATH.
