### PR TITLE
Ensure configured taps are tapped before packages are installed.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,11 @@
   when: homebrew_binary.stat.exists == false
   sudo: yes
 
+# Tap.
+- name: Ensure configured taps are tapped.
+  homebrew_tap: "tap={{ item }} state=present"
+  with_items: homebrew_taps
+
 # Brew.
 - name: Ensure configured homebrew packages are installed.
   homebrew: "name={{ item }} state=present"
@@ -45,11 +50,6 @@
 - name: Upgrade all homebrew packages (if configured).
   homebrew: update_homebrew=yes upgrade_all=yes
   when: homebrew_upgrade_all_packages
-
-# Tap.
-- name: Ensure configured taps are tapped.
-  homebrew_tap: "tap={{ item }} state=present"
-  with_items: homebrew_taps
 
 # Cask.
 - name: Get list of apps installed with cask.


### PR DESCRIPTION
Before this commit, any formulas in the homebrew_installed_packages list that were from taps would fail to install on a fresh system (or where the taps have yet to be tapped).  For example, using the playbook from https://github.com/geerlingguy/mac-dev-playbook would result in an error as the formula 'brew-cask' cannot be found.