### PR TITLE
Add setting to allow skipping cask tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@ homebrew_cask_apps:
   - firefox
 
 homebrew_cask_appdir: /Applications
+
+skip_cask: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,10 +57,11 @@
   register: homebrew_cask_list
   always_run: yes
   changed_when: false
+  when: skip_cask == false
 
 # Use command module instead of homebrew_cask so appdir can be used.
 - name: Install configured cask applications.
   command: >
     bash -l -c '{{ homebrew_brew_bin_path }}/brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}'
   with_items: homebrew_cask_apps
-  when: "'{{ item }}' not in homebrew_cask_list.stdout"
+  when: skip_cask == false and "'{{ item }}' not in homebrew_cask_list.stdout"


### PR DESCRIPTION
This PR makes no change to the default behavior of the role, but allows cask steps to be skipped when they're unneeded. 