### PR TITLE
update bin perms after homebrew is installed else fail like this

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,14 @@
     state: directory
   sudo: yes
 
+- name: Ensure homebrew is installed.
+  git:
+    repo: git://github.com/Homebrew/homebrew.git
+    version: master
+    dest: "{{ homebrew_install_path }}"
+    update: no
+    accept_hostkey: yes
+
 - name: Ensure proper permissions on homebrew_brew_bin_path dirs.
   file:
     path: "{{ homebrew_brew_bin_path }}"
@@ -15,14 +23,6 @@
     state: directory
     recurse: true
   sudo: yes
-
-- name: Ensure homebrew is installed.
-  git:
-    repo: git://github.com/Homebrew/homebrew.git
-    version: master
-    dest: "{{ homebrew_install_path }}"
-    update: no
-    accept_hostkey: yes
 
 - name: Check if homebrew binary is already in place.
   stat: "path={{ homebrew_brew_bin_path }}/brew"


### PR DESCRIPTION
```
TASK: [geerlingguy.homebrew | Ensure homebrew is installed.] ****************** 
failed: [vm] => {"cmd": "/usr/bin/git clone --origin origin --branch master git://github.com/Homebrew/homebrew.git /usr/local", "failed": true, "rc": 128}
stderr: fatal: destination path '/usr/local' already exists and is not an empty directory.

msg: fatal: destination path '/usr/local' already exists and is not an empty directory.

FATAL: all hosts have already failed -- abortin
```