### PR TITLE
Ignore errors when cloning Homebrew repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
     dest: "{{ homebrew_install_path }}"
     update: no
     accept_hostkey: yes
+  ignore_errors: true
 
 - name: Ensure proper permissions on homebrew_brew_bin_path dirs.
   file:


### PR DESCRIPTION
The git task fails to continue when `/usr/local` is not empty. This
happens when `ansible` was installed using `pip` (adds
`ansible-playbook` and others to `/usr/local/bin`).