### PR TITLE
Fix deprecated use of bare variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,12 +54,12 @@
 # Tap.
 - name: Ensure configured taps are tapped.
   homebrew_tap: "tap={{ item }} state=present"
-  with_items: homebrew_taps
+  with_items: "{{ homebrew_taps }}"
 
 # Brew.
 - name: Ensure configured homebrew packages are installed.
   homebrew: "name={{ item }} state=present"
-  with_items: homebrew_installed_packages
+  with_items: "{{ homebrew_installed_packages }}"
 
 - name: Upgrade all homebrew packages (if configured).
   homebrew: update_homebrew=yes upgrade_all=yes


### PR DESCRIPTION
```
TASK [geerlingguy.homebrew : Ensure configured taps are tapped.] ***************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so
that the environment value uses the full variable syntax ('{{homebrew_taps}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.

TASK [geerlingguy.homebrew : Ensure configured homebrew packages are installed.] ***
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so
that the environment value uses the full variable syntax
('{{homebrew_installed_packages}}'). This feature will be removed in a future release.
 Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

