### PR TITLE
More Cask options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Taps you would like to make sure Homebrew has tapped.
 
 Apps you would like to have installed via `cask`. Search for popular apps on http://caskroom.io/ to see if they're available for install via Cask. Cask will not be used if it is not included in the list of taps in the `homebrew_taps` variable.
 
-    homebrew_cask_appdir: /Applications
+    homebrew_cask_opts: >
+      --appdir=/Applications
 
-Directory where applications installed via `cask` should be installed.
+Additional options for `cask`. See [official documentation](https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md#options) for an exhaustive list of options.
 
     homebrew_use_brewfile: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,9 @@ homebrew_taps:
 homebrew_cask_apps:
   - firefox
 
-homebrew_cask_appdir: /Applications
+# add more caskroom options here
+homebrew_cask_opts: >
+  --appdir=/Applications
 
 homebrew_use_brewfile: true
 homebrew_brewfile_dir: '~'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,11 +73,12 @@
   always_run: yes
   changed_when: false
 
-# Use command module instead of homebrew_cask so appdir can be used.
+# Use environment module to set additional Cask options (e.g. appdir)
 - name: Install configured cask applications.
-  command: >
-    bash -l -c '{{ homebrew_brew_bin_path }}/brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}'
+  homebrew_cask: "name={{ item }} state=present"
   with_items: "{{ homebrew_cask_apps }}"
+  environment:
+    HOMEBREW_CASK_OPTS: "{{ homebrew_cask_opts }}"
   when: "'{{ item }}' not in homebrew_cask_list.stdout"
 
 - name: Check for Brewfile.


### PR DESCRIPTION
Replaced homebrew_cask_appdir with a more generic homebrew_cask_opts, to allow setting more options. I was specifically looking for a non-default Caskroom location, but this can be used for other options as well.