### PR TITLE
Use alternate installation method [fix #18]

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,14 +13,35 @@
     state: directory
   become: yes
 
-- name: Ensure homebrew is installed.
-  git:
-    repo: git://github.com/Homebrew/homebrew.git
-    version: master
-    dest: "{{ homebrew_install_path }}"
-    update: no
-    accept_hostkey: yes
-    depth: 1
+- name: Init git repo in homebrew_install_path
+  shell: git init -q
+  args:
+    chdir: "{{ homebrew_install_path }}"
+
+- name: Set repo remote url
+  shell: git config remote.origin.url https://github.com/Homebrew/brew
+  args:
+    chdir: "{{ homebrew_install_path }}"
+
+- name: Set repo remote fetch ref
+  shell: git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  args:
+    chdir: "{{ homebrew_install_path }}"
+
+- name: Ensure line endings are not mudged on checkout
+  shell: git config core.autocrlf false
+  args:
+    chdir: "{{ homebrew_install_path }}"
+
+- name: Fetch repo origin
+  shell: git fetch origin master:refs/remotes/origin/master -n --depth=1
+  args:
+    chdir: "{{ homebrew_install_path }}"
+
+- name: Reset repo to master's head
+  shell: git reset --hard origin/master
+  args:
+    chdir: "{{ homebrew_install_path }}"
 
 - name: Ensure proper permissions on homebrew_brew_bin_path dirs.
   file:


### PR DESCRIPTION
This is a fix proposition for #18

On El Capitan the chmod of /usr/local was not enough to fix the problem in my case. I had to replicate the homebrew isntall script steps using the ansible shell module instead. Now everything is fully functional again and the `fatal: destination path '/usr/local' already exists and is not an empty directory.` error message is gone.

I'm aware this is a big change. And might not be the most maintainable one. But it works, and is pretty transparent. 
I would understand if it would not get merged, but this might still be a good reference for people who still run into the problem after trying solutions proposed in #18.

Please review and test.
Cheers 