### PR TITLE
Use the tmp directory when installing homebrew. Fixes #18

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,14 +13,24 @@
     state: directory
   become: yes
 
-- name: Ensure homebrew is installed.
-  git:
-    repo: git://github.com/Homebrew/homebrew.git
+- stat: path="{{ homebrew_brew_bin_path }}/brew"
+  register: homebrew_binary
+
+- name: Clone homebrew.
+  git: 
+    repo: https://github.com/Homebrew/brew.git
+    dest: /tmp/brew
     version: master
-    dest: "{{ homebrew_install_path }}"
     update: no
     accept_hostkey: yes
     depth: 1
+  when: homebrew_binary.stat.islnk is not defined
+
+- name: Move homebrew to install directory
+  synchronize:
+    src: /tmp/brew/
+    dest: /usr/local
+  when: homebrew_binary.stat.islnk is not defined
 
 - name: Ensure proper permissions on homebrew_brew_bin_path dirs.
   file:


### PR DESCRIPTION
This resolves #18 for me, and hopefully others.

This is the first time I have used ansible, so feel free to suggest how I could clean it up and I will make the changes as quickly as I can.  This is working for me on El Cap.