### PR TITLE
Add install options to packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ The path where `brew` will be installed.
     homebrew_installed_packages:
       - ssh-copy-id
       - pv
+      - vim
 
 Packages you would like to make sure are installed via `brew install`.
+
+    homebrew_package_options:
+      pv:
+        - with-gettext
+      vim:
+        - with-lua
+        - with-python3
+
+Optional list of package options to add to `brew install`.
 
     homebrew_upgrade_all_packages: no
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ homebrew_installed_packages:
   - ssh-copy-id
   - pv
 
+homebrew_package_options:
+
 homebrew_upgrade_all_packages: no
 
 homebrew_taps:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
 
 # Brew.
 - name: Ensure configured homebrew packages are installed.
-  homebrew: "name={{ item }} state=present"
+  homebrew: "name={{ item }} state=present install_options={{ homebrew_package_options[item]|default(omit)|join(',')}}"
   with_items: "{{ homebrew_installed_packages }}"
 
 - name: Upgrade all homebrew packages (if configured).


### PR DESCRIPTION
This resolves https://github.com/geerlingguy/ansible-role-homebrew/issues/31 by allowing you to specify a dict of packages and options in the variables whilst maintaining backward compatibility:

``` yaml
...

homebrew_installed_packages:
  - vim

homebrew_package_options:
  vim:
    - with-lua
    - with-luajit

...
```
