### PR TITLE
Removed shallow clone.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,6 @@
     dest: "{{ homebrew_install_path }}"
     update: no
     accept_hostkey: yes
-    depth: 1
 
 - name: Ensure proper permissions on homebrew_brew_bin_path dirs.
   file:


### PR DESCRIPTION
Removed shallow clone from task
"Ensure homebrew is installed"

The Ansible git module does not appear to support the depth option in v2.1.1.0 and breaks the role, despite still being listed on http://docs.ansible.com/ansible/git_module.html