### PR TITLE
Fixes #47: do not install any arbitrary components by default:

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,18 +5,29 @@ homebrew_prefix: /usr/local
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 homebrew_brew_bin_path: /usr/local/bin
 
-homebrew_installed_packages:
-  - ssh-copy-id
-  - pv
+# List of packages to be installed, e.g.
+#   homebrew_installed_packages:
+#     - ssh-copy-id
+#     - pv
+homebrew_installed_packages: []
 
 homebrew_upgrade_all_packages: no
 
-homebrew_taps:
-  - homebrew/core
-  - caskroom/cask
+# List of taps to be added, e.g.
+#   homebrew_taps:
+#     - homebrew/dupes
+#     - homebrew/science
+# Note that homebrew/core is added automatically when brew is installed
+# and caskroom/cask will be added as soon as the first cask is installed
+# (e.g. using homebrew_cask_apps below); see also
+# https://github.com/Homebrew/brew/blob/master/docs/Interesting-Taps-%26-Forks.md
+homebrew_taps: []
 
-homebrew_cask_apps:
-  - firefox
+# List of casks to be installed, e.g.
+#   homebrew_cask_apps:
+#     - firefox
+# see also https://caskroom.github.io
+homebrew_cask_apps: []
 
 homebrew_cask_appdir: /Applications
 


### PR DESCRIPTION
instead, document how this is achieved, link to official documentation

NOTE: I would like to have Ansible print explicitly that it skips over
package / tap / cask setup tasks if the corresponding list is empty
instead of just printing the task and then moving on; this seems more in
line with the other tasks. However, a when statement is not evaluated if
a list iterated over using with_items is empty;
see also http://stackoverflow.com/a/35471907
possibly related: https://github.com/ansible/ansible/issues/1408