### PR TITLE
Fix deprecation warning: use check_mode instead of always_run.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   shell: whoami
   register: homebrew_whoami
   changed_when: false
-  always_run: true
+  check_mode: no
 
 - name: Ensure Homebrew parent directory has correct permissions.
   file:
@@ -86,7 +86,7 @@
   command: >
     bash -l -c '{{ homebrew_brew_bin_path }}/brew cask list'
   register: homebrew_cask_list
-  always_run: yes
+  check_mode: no
   changed_when: false
 
 # Use command module instead of homebrew_cask so appdir can be used.


### PR DESCRIPTION
The latter is deprecated and will be removed in Ansible 2.4.