### PR TITLE
Install OSX command line tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ osx_image: xcode7.3
 
 before_install:
   # Uninstall existing brew installation.
-  - 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"'
+  - curl -sLO https://raw.githubusercontent.com/Homebrew/install/master/uninstall
+  - chmod +x ./uninstall
+  - ./uninstall --force
   - rm -rf /usr/local/Homebrew
   - rm -rf /usr/local/Caskroom
   - rm -rf /usr/local/bin/brew
@@ -19,12 +21,15 @@ install:
   - sudo pip install ansible
 
   # Add ansible.cfg to pick up roles path.
-  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+  - "{ echo '[defaults]'; echo 'roles_path = ../:../roles:./roles'; } >> ansible.cfg"
 
   # Add a hosts file.
   - sudo mkdir -p /etc/ansible
   - sudo touch /etc/ansible/hosts
   - "echo -e '[local]\nlocalhost ansible_connection=local' | sudo tee -a /etc/ansible/hosts > /dev/null"
+
+  # Install dependency roles.
+  - ansible-galaxy install -r requirements.yml -p ./roles
 
 script:
   # Check the role/playbook's syntax.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The directory where your Brewfile is located.
 
 ## Dependencies
 
-None.
+* [elliotweiser.osx-command-line-tools](https://galaxy.ansible.com/elliotweiser/osx-command-line-tools/)
 
 ## Example Playbook
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
-dependencies: []
+dependencies:
+  - role: elliotweiser.osx-command-line-tools
 
 galaxy_info:
   author: geerlingguy
@@ -8,7 +9,7 @@ galaxy_info:
   license: "license (BSD, MIT)"
   min_ansible_version: 1.9
   platforms:
-    - name: GenericUNIX
+    - name: MacOSX
       versions:
         - all
         - any

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,1 @@
+- src: elliotweiser.osx-command-line-tools

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Homebrew setup prerequisites.
 - name: Get current account's username.
-  shell: whoami
+  command: whoami
   register: homebrew_whoami
   changed_when: false
   always_run: true
@@ -9,6 +9,7 @@
 - name: Ensure Homebrew parent directory has correct permissions.
   file:
     path: "{{ homebrew_prefix }}"
+    owner: root
     group: admin
     state: directory
     mode: 0775


### PR DESCRIPTION
Summary of Changes
==================

Since the OS X Command Line Tools are a hard dependency for Homebrew, this
role will now make sure that they are installed. If they are already
installed, those steps will be skipped. This makes using this role easier
to use when provisioning MacOS, especially when the destination host is not
the same as the control node.

Other related changes:

* `meta/main.yml`: specifies platform `MacOSX` instead of `GenericUNIX`
* `.travis.yml`: Fix homebrew uninstall process-- the old way hangs.
* `tasks/main.yml`: Ensure `root` is the owner of `homebrew_prefix` (`/usr/local`)