### PR TITLE
Fix Sierra macOS issue with dir ownership which was preventing linking brew packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,11 +34,13 @@
     depth: 1
 
 # Adjust Homebrew permissions.
-- name: Ensure proper permissions on homebrew_brew_bin_path dirs.
+- name: Ensure proper permissions and ownership on homebrew_brew_bin_path dirs.
   file:
     path: "{{ homebrew_brew_bin_path }}"
     mode: 0775
     state: directory
+    owner: "{{ homebrew_whoami.stdout }}"
+    group: admin
   become: yes
 
 - name: Ensure proper ownership on homebrew_install_path subdirs.


### PR DESCRIPTION
Fix provided as a result of the discussion here https://github.com/geerlingguy/mac-dev-playbook/issues/27 

I found that the ansible task would execute fine but silently it would not complete the required linking between /usr/local/bin and packages in /usr/local/Cellar. This would result in no packages being available on the path

The breaking change with Sierra macOS is pretty much summed up here http://apple.stackexchange.com/questions/261695/new-mbp-with-sierra-usr-local-bin-no-longer-accessible-unless-root