### PR TITLE
Support multiple OS X versions being built by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
 ---
 sudo: required
 language: objective-c
-# 10.11 (see https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version)
-osx_image: xcode7.3
+
+# When you define multiple variables per line in the env array (matrix variables), one build is triggered per item.
+# see https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item
+# see https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
+env:
+  - OSX_IMAGE_KEY=xcode7.3 OSX_IMAGE_VERSION=10.11
+  - OSX_IMAGE_KEY=xcode8.2 OSX_IMAGE_VERSION=10.12
+
+osx_image: $OSX_IMAGE_KEY
 
 before_install:
   # Uninstall existing brew installation.
   - 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"'
+
+  # Give permissions needed for Sierra macOS
+  - if [ "$OSX_IMAGE_VERSION" == "10.12" ]; then
+    sudo chown -R $(whoami) /usr/local;
+    fi
+
   - rm -rf /usr/local/Homebrew
   - rm -rf /usr/local/Caskroom
   - rm -rf /usr/local/bin/brew
+
+  # Reset permissions for Sierra macOS
+  - if [ "$OSX_IMAGE_VERSION" == "10.12" ]; then
+    sudo chmod 0755 /usr/local;
+    sudo chown root:wheel /usr/local;
+    fi
 
 install:
   # Install pip.


### PR DESCRIPTION
To catch breakages due to OS X upgrades as seen in https://github.com/geerlingguy/ansible-role-homebrew/pull/55 this PR is to get Travis to run builds against multiple versions of OS X in parallel.

This gives us

![screen shot 2016-12-29 at 22 06 55](https://cloud.githubusercontent.com/assets/12397324/21555791/4a97c7dc-ce13-11e6-931f-4e4c5e121ab6.png)

Different behaviour is required for Sierra macOS due to ownership changing and now becoming `root:wheel /usr/local` and if not dealt with it causes a problem with the set up of the Travis OS X image (it needs cleaning up as it comes pre-configured with a version of homebrew)

![97f84327-7c7d-4268-937c-0767d24e7874](https://cloud.githubusercontent.com/assets/12397324/21555772/f9f19916-ce12-11e6-97e0-2cd0991a025a.png)

A workaround is provided by the relevant if statements in the Travis yml
