### PR TITLE
Put install tasks for cask before brew to fix dependencies on Java

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,15 +75,6 @@
   homebrew_tap: "tap={{ item }} state=present"
   with_items: "{{ homebrew_taps }}"
 
-# Brew.
-- name: Ensure configured homebrew packages are installed.
-  homebrew: "name={{ item }} state=present"
-  with_items: "{{ homebrew_installed_packages }}"
-
-- name: Upgrade all homebrew packages (if configured).
-  homebrew: update_homebrew=yes upgrade_all=yes
-  when: homebrew_upgrade_all_packages
-
 # Cask.
 - name: Get list of apps installed with cask.
   command: >
@@ -98,6 +89,15 @@
     bash -l -c '{{ homebrew_brew_bin_path }}/brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}'
   with_items: "{{ homebrew_cask_apps }}"
   when: "'{{ item }}' not in homebrew_cask_list.stdout"
+
+# Brew.
+- name: Ensure configured homebrew packages are installed.
+  homebrew: "name={{ item }} state=present"
+  with_items: "{{ homebrew_installed_packages }}"
+
+- name: Upgrade all homebrew packages (if configured).
+  homebrew: update_homebrew=yes upgrade_all=yes
+  when: homebrew_upgrade_all_packages
 
 - name: Check for Brewfile.
   stat:


### PR DESCRIPTION
For Java devs this is a fundamental set up. Maven is a core Java build tool, and would be standard in most set ups. Java is provided as a cask and needs to be installed prior to brew install on any packages which run on Java. 

![8e694635-4126-4d78-a3f2-d6d6ddee05ab](https://cloud.githubusercontent.com/assets/12397324/21566732/bd6b97e0-ce9d-11e6-8985-49547bb70b56.png)

Those who do not use Maven would likely use Gradle

![3ee5199a-4605-428a-b0a2-b5d11adc4636](https://cloud.githubusercontent.com/assets/12397324/21566756/0a19ccb0-ce9e-11e6-8b8a-0e3c9255c66d.png)

This also affects installs such as [elastic search](http://www.inanzzz.com/index.php/post/wv82/solution-for-elasticsearch-java-is-required-to-install-this-formula-in-mac-os)