### PR TITLE
Enhancement - Clear Caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Whether to install via a Brewfile. If so, you will need to install the `homebrew
 
 The directory where your Brewfile is located.
 
+    homebrew_clear_cache: false
+
+Set to `true` to remove the Hombrew cache after any new software is installed.
+
 ## Dependencies
 
   - [elliotweiser.osx-command-line-tools][dep-osx-clt-role]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ homebrew_repo: https://github.com/Homebrew/brew
 
 homebrew_prefix: /usr/local
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
-homebrew_brew_bin_path: /usr/local/bin
+homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
 
 homebrew_installed_packages: []
 
@@ -23,3 +23,5 @@ homebrew_cask_appdir: /Applications
 
 homebrew_use_brewfile: true
 homebrew_brewfile_dir: '~'
+
+homebrew_clear_cache: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# handlers for ansible-role-homebrew
+
+- name: Clear homebrew cache
+  file:
+    path: "{{ homebrew_cache_path.stdout | trim }}"
+    state: absent
+  when: 'homebrew_clear_cache | bool'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,6 +94,11 @@
   command: "{{ homebrew_brew_bin_path }}/brew update --force"
   when: homebrew_binary.stat.exists == false
 
+- name: Where is the cache?
+  command: "{{ homebrew_brew_bin_path }}/brew --cache"
+  register: homebrew_cache_path
+  changed_when: false
+
 # Tap.
 - name: Ensure configured taps are tapped.
   homebrew_tap: "tap={{ item }} state=present"
@@ -106,6 +111,8 @@
     state: present
     install_options: "appdir={{ homebrew_cask_appdir }}"
   with_items: "{{ homebrew_cask_apps }}"
+  notify:
+    - Clear homebrew cache
 
 - name: Ensure blacklisted cask applications are not installed.
   homebrew_cask: "name={{ item }} state=absent"
@@ -118,6 +125,8 @@
     install_options: "{{ item.install_options | default(omit) }}"
     state: present
   with_items: "{{ homebrew_installed_packages }}"
+  notify:
+    - Clear homebrew cache
 
 - name: Ensure blacklisted homebrew packages are not installed.
   homebrew: "name={{ item }} state=absent"
@@ -126,6 +135,8 @@
 - name: Upgrade all homebrew packages (if configured).
   homebrew: update_homebrew=yes upgrade_all=yes
   when: homebrew_upgrade_all_packages
+  notify:
+    - Clear homebrew cache
 
 - name: Check for Brewfile.
   stat:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,11 @@
 ---
 - hosts: localhost
-
+  vars:
+    homebrew_clear_cache: true
+    homebrew_installed_packages:
+      - ssh-copy-id
+    homebrew_cask_apps:
+      - firefox
   roles:
     - elliotweiser.osx-command-line-tools
     - ansible-role-homebrew


### PR DESCRIPTION
Summary of Changes
==================

This change provides the option to clear the Homebrew cache after any software
installation. The handler will only run if the related role variable is set.

Why?
----

The benefit is that this saves disk space and can avoid installation/execution
of potentially corrupt software, but the cost is the time saved by avoiding
re-downloading what were otherwise cached files (fixes #40).