### PR TITLE
Resolve deprecation warning

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - role: elliotweiser.osx-command-line-tools
+  - elliotweiser.osx-command-line-tools
 
 galaxy_info:
   author: geerlingguy


### PR DESCRIPTION
Fixes this deprecation warning received upon install:
```
[DEPRECATION WARNING]: The comma separated role spec format, use the yaml/explicit format instead..
This feature will be removed in a future release.                                                                                                            
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.   
```

https://github.com/debops/ansible-sshd/issues/35#issuecomment-223684840