### PR TITLE
Do not fail on already installed cask items

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,7 +91,15 @@
     name: "{{ item }}"
     state: present
     install_options: "appdir={{ homebrew_cask_appdir }}"
+  register: output
   with_items: "{{ homebrew_cask_apps }}"
+  ignore_errors: yes
+
+- name: Fail if any cask install returned not zero and wasn't already installed.
+  fail:
+    msg: "Failed to install {{ item.item }}: {{ item.msg }}"
+  when: "'failed' in item and item.failed and 'there is already an App' not in item.msg and 'already installed' not in item.msg"
+  with_items: "{{ output.results }}"
 
 - name: Check for Brewfile.
   stat:


### PR DESCRIPTION
Currently, cask installs fail if they where already installed, leading ansible to not proceed with following roles. Unfortunately cask returns a failure if an app already has an install. This is a working solution I came up with, happy to get some input on it.