### PR TITLE
Relax /usr/local directory owner and permissions check.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,7 @@
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
-    group: admin
     state: directory
-    mode: 0775
   become: yes
 
 - name: Ensure Homebrew directory exists.


### PR DESCRIPTION
Installed 10.13 (High Sierra) and found this to be needed.

The home-brew /usr/local dir does not need to be owned by admin (or have a 775 mode).