### PR TITLE
Added check for Mac OS X version.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,23 @@
 ---
 # Homebrew setup prerequisites.
-- name: Ensure Homebrew parent directory has correct permissions.
+
+- name: Ensure Homebrew parent directory has correct permissions (on High Sierra).
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
     state: directory
   become: yes
+  when: "ansible_distribution_version.startswith('10.13')"
+
+- name: Ensure Homebrew parent directory has correct permissions (on non-'High Sierra' versions of Mac OS X).
+  file:
+    path: "{{ homebrew_prefix }}"
+    owner: root
+    group: admin
+    state: directory
+    mode: 0775
+  become: yes
+  when: "not ansible_distribution_version.startswith('10.13')"
 
 - name: Ensure Homebrew directory exists.
   file:


### PR DESCRIPTION
If High Sierra, use different permissions for '/usr/local' that when older version of Mac OS X.

This should fix #76 . Not sure if what I did is the best way to test for a Mac OS X version, but I reckon it's probably good enough.