### PR TITLE
Make user and group configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,14 @@
 homebrew_repo: https://github.com/Homebrew/brew
 
 homebrew_prefix: /usr/local
+homebrew_prefix_owner: root
+homebrew_prefix_group: admin
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
+homebrew_install_path_owner: "{{ ansible_user_id }}"
+homebrew_install_path_group: admin
 homebrew_brew_bin_path: /usr/local/bin
+homebrew_brew_bin_path_owner: "{{ ansible_user_id }}"
+homebrew_brew_bin_path_group: admin
 
 homebrew_installed_packages:
   - ssh-copy-id

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Ensure Homebrew parent directory has correct permissions (on High Sierra).
   file:
     path: "{{ homebrew_prefix }}"
-    owner: root
+    owner: "{{ homebrew_prefix_owner }}"
     state: directory
   become: yes
   when: "ansible_distribution_version.startswith('10.13')"
@@ -12,8 +12,8 @@
 - name: Ensure Homebrew parent directory has correct permissions (on non-'High Sierra' versions of Mac OS X).
   file:
     path: "{{ homebrew_prefix }}"
-    owner: root
-    group: admin
+    owner: "{{ homebrew_prefix_owner }}"
+    group: "{{ homebrew_prefix_group }}"
     state: directory
     mode: 0775
   become: yes
@@ -22,8 +22,8 @@
 - name: Ensure Homebrew directory exists.
   file:
     path: "{{ homebrew_install_path }}"
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_install_path_owner }}"
+    group: "{{ homebrew_install_path_group }}"
     state: directory
     mode: 0775
   become: yes
@@ -43,8 +43,8 @@
   file:
     path: "{{ homebrew_brew_bin_path }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_brew_bin_path_owner }}"
+    group: "{{ homebrew_brew_bin_path_group }}"
     mode: 0775
   become: yes
 
@@ -52,8 +52,8 @@
   file:
     path: "{{ homebrew_install_path }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_install_path_owner }}"
+    group: "{{ homebrew_install_path_group }}"
     recurse: true
   become: yes
 


### PR DESCRIPTION
Some systems might not have or might not want to use the hard-coded user
and group. This keeps the same values by default but allows configuring
them to suit the user’s needs.