### PR TITLE
Revert "Use underscores instead of dashes for dependencies"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The directory where your Brewfile is located.
 
 ## Dependencies
 
-  - [elliotweiser.osx_command_line_tools][dep-osx-clt-role]
+  - [elliotweiser.osx-command-line-tools][dep-osx-clt-role]
 
 ## Example Playbook
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - elliotweiser.osx_command_line_tools
+  - elliotweiser.osx-command-line-tools
 
 galaxy_info:
   author: geerlingguy

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,2 @@
 ---
-- src: elliotweiser.osx_command_line_tools
+- src: elliotweiser.osx-command-line-tools

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,5 @@
 - hosts: localhost
 
   roles:
-    - elliotweiser.osx_command_line_tools
+    - elliotweiser.osx-command-line-tools
     - ansible-role-homebrew


### PR DESCRIPTION
This reverts commit e1efb76a448de96f73cc06c8711d473313ed9cda.

Related to ansible/galaxy#775