### PR TITLE
Don't accept SSH host key by default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,6 @@
     version: master
     dest: "{{ homebrew_install_path }}"
     update: no
-    accept_hostkey: yes
     depth: 1
 
 # Adjust Homebrew permissions.


### PR DESCRIPTION
This change fixes a potential security vulnerability that arises
when cloning the Homebrew repository over SSH. The default case
uses anonymous HTTPS from GitHub, so most users probably won't be
impacted.

If a potential user is impacted by this change, the host key can
be cached for the "first time" by combining the `ssh-keyscan`
command with the `known_hosts` Ansible module. These steps could be
taken during a playbook's `pre_tasks`.

Fixes #102