### PR TITLE
Support 10.14 when checking directory permissions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: Homebrew for Mac OS X
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.9
+  min_ansible_version: 2.5
   platforms:
     - name: MacOSX
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 # Homebrew setup prerequisites.
-- name: Ensure Homebrew parent directory has correct permissions (on High Sierra and above).
+- name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
     state: directory
   become: yes
-  when: "ansible_distribution_version.startswith('10.13') or ansible_distribution_version.startswith('10.14')"
+  when: "ansible_distribution_version | version('10.13', '>=')"
 
-- name: Ensure Homebrew parent directory has correct permissions (on non-'High Sierra' versions of Mac OS X).
+- name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
@@ -16,7 +16,7 @@
     state: directory
     mode: 0775
   become: yes
-  when: "not ansible_distribution_version.startswith('10.13') and not ansible_distribution_version.startswith('10.14')"
+  when: "ansible_distribution_version | version('10.13', '<')"
 
 - name: Ensure Homebrew directory exists.
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 # Homebrew setup prerequisites.
-- name: Ensure Homebrew parent directory has correct permissions (on High Sierra).
+- name: Ensure Homebrew parent directory has correct permissions (on High Sierra and above).
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
     state: directory
   become: yes
-  when: "ansible_distribution_version.startswith('10.13')"
+  when: "ansible_distribution_version.startswith('10.13') or ansible_distribution_version.startswith('10.14')"
 
 - name: Ensure Homebrew parent directory has correct permissions (on non-'High Sierra' versions of Mac OS X).
   file:
@@ -16,7 +16,7 @@
     state: directory
     mode: 0775
   become: yes
-  when: "not ansible_distribution_version.startswith('10.13')"
+  when: "not ansible_distribution_version.startswith('10.13') and not ansible_distribution_version.startswith('10.14')"
 
 - name: Ensure Homebrew directory exists.
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     owner: root
     state: directory
   become: yes
-  when: "ansible_distribution_version | version('10.13', '>=')"
+  when: "ansible_distribution_version is version('10.13', '>=')"
 
 - name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
   file:
@@ -16,7 +16,7 @@
     state: directory
     mode: 0775
   become: yes
-  when: "ansible_distribution_version | version('10.13', '<')"
+  when: "ansible_distribution_version is version('10.13', '<')"
 
 - name: Ensure Homebrew directory exists.
   file:


### PR DESCRIPTION
I checked to see if there was any better way to check the OS version but couldn't really see a good one since the major version is always 10. Let me know if there's a better way to do this check.