### PR TITLE
make homebrew_cask accept manual installed apps

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ homebrew_cask_apps: []
 homebrew_cask_uninstalled_apps: []
 
 homebrew_cask_appdir: /Applications
+homebrew_cask_accept_external_apps: false
 
 homebrew_use_brewfile: true
 homebrew_brewfile_dir: '~'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,7 +110,7 @@
     name: "{{ item }}"
     state: present
     install_options: "appdir={{ homebrew_cask_appdir }}"
-    accept_external_apps: {{ homebrew_cask_accept_external_apps }}
+    accept_external_apps: "{{ homebrew_cask_accept_external_apps }}"
   with_items: "{{ homebrew_cask_apps }}"
   notify:
     - Clear homebrew cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,7 +110,7 @@
     name: "{{ item }}"
     state: present
     install_options: "appdir={{ homebrew_cask_appdir }}"
-    accept_external_apps: true
+    accept_external_apps: {{ homebrew_cask_accept_external_apps }}
   with_items: "{{ homebrew_cask_apps }}"
   notify:
     - Clear homebrew cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,6 +110,7 @@
     name: "{{ item }}"
     state: present
     install_options: "appdir={{ homebrew_cask_appdir }}"
+    accept_external_apps: true
   with_items: "{{ homebrew_cask_apps }}"
   notify:
     - Clear homebrew cache


### PR DESCRIPTION
since Ansible 2.5 instead of failing on a manually installed App you can specify accept_external_apps: true