### PR TITLE
Add homebrew_user and homebrew_group variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ The directory where your Brewfile is located.
 
 Set to `true` to remove the Hombrew cache after any new software is installed.
 
+    homebrew_user: "{{ ansible_user_id }}"
+
+The user that you would like to install Homebrew as.
+
+    homebrew_group: "{{ ansible_group_id }}"
+
+The group that you would like to use while installing Homebrew.
+
 ## Dependencies
 
   - [elliotweiser.osx-command-line-tools][dep-osx-clt-role]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Set to `true` to remove the Hombrew cache after any new software is installed.
 
 The user that you would like to install Homebrew as.
 
-    homebrew_group: "{{ ansible_group_id }}"
+    homebrew_group: "{{ ansible_user_gid }}"
 
 The group that you would like to use while installing Homebrew.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,8 @@
     dest: "{{ homebrew_install_path }}"
     update: no
     depth: 1
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 # Adjust Homebrew permissions.
 - name: Ensure proper permissions and ownership on homebrew_brew_bin_path dirs.
@@ -125,10 +127,14 @@
   with_items: "{{ homebrew_cask_apps }}"
   notify:
     - Clear homebrew cache
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 - name: Ensure blacklisted cask applications are not installed.
   homebrew_cask: "name={{ item }} state=absent"
   with_items: "{{ homebrew_cask_uninstalled_apps }}"
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 # Brew.
 - name: Ensure configured homebrew packages are installed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Determine Homebrew ownership variables
+  set_fact:
+    homebrew_user: '{{ homebrew_user | default(ansible_user_id) }}'
+    homebrew_group: '{{ homebrew_group | default(ansible_user_gid) }}'
+
 # Homebrew setup prerequisites.
 - name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
   file:
@@ -21,8 +26,8 @@
 - name: Ensure Homebrew directory exists.
   file:
     path: "{{ homebrew_install_path }}"
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_user }}"
+    group: "{{ homebrew_group }}"
     state: directory
     mode: 0775
   become: yes
@@ -41,8 +46,8 @@
   file:
     path: "{{ homebrew_brew_bin_path }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_user }}"
+    group: "{{ homebrew_group }}"
     mode: 0775
   become: yes
 
@@ -50,8 +55,8 @@
   file:
     path: "{{ homebrew_install_path }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_user }}"
+    group: "{{ homebrew_group }}"
   become: yes
 
 # Place brew binary in proper location and complete setup.
@@ -72,8 +77,8 @@
   file:
     path: "{{ homebrew_prefix }}/{{ item }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
-    group: admin
+    owner: "{{ homebrew_user }}"
+    group: "{{ homebrew_group }}"
   become: yes
   with_items:
     - Cellar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,8 @@
 - name: Force update brew after installation.
   command: "{{ homebrew_brew_bin_path }}/brew update --force"
   when: not homebrew_binary.stat.exists
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 - name: Where is the cache?
   command: "{{ homebrew_brew_bin_path }}/brew --cache"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,6 +112,8 @@
 - name: Ensure configured taps are tapped.
   homebrew_tap: "tap={{ item }} state=present"
   with_items: "{{ homebrew_taps }}"
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 # Cask.
 - name: Install configured cask applications.
@@ -137,16 +139,22 @@
   with_items: "{{ homebrew_installed_packages }}"
   notify:
     - Clear homebrew cache
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 - name: Ensure blacklisted homebrew packages are not installed.
   homebrew: "name={{ item }} state=absent"
   with_items: "{{ homebrew_uninstalled_packages }}"
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 - name: Upgrade all homebrew packages (if configured).
   homebrew: update_homebrew=yes upgrade_all=yes
   when: homebrew_upgrade_all_packages
   notify:
     - Clear homebrew cache
+  become: yes
+  become_user: "{{ homebrew_user }}"
 
 - name: Check for Brewfile.
   stat:
@@ -157,3 +165,5 @@
 - name: Install from Brewfile.
   command: "brew bundle chdir={{ homebrew_brewfile_dir }}"
   when: homebrew_brewfile.stat.exists and homebrew_use_brewfile
+  become: yes
+  become_user: "{{ homebrew_user }}"


### PR DESCRIPTION
New Description
===============

This PR adds new variables `homebrew_user` and `homebrew_group` to enable users to specify an alternative user (and Unix group) when `ansible_user_id` is insufficient. See the conversation below for details.

Original Description
====================

If the default install path of `/usr/local` is used, then the user creating directories within that path must be root. 

My use case is that I create a `buildkite` user for use on our CI server as part of my role. The user does not exist at the start of my role, and I expect at the end of the process that the user will be unprivileged. 

I'd been doing the following to get this to work:

```yaml
  roles:
    - role: geerlingguy.homebrew
      ansible_user_id: buildkite
      become: yes
      become_user: buildkite
```

Maybe I'm doing this wrong?