### PR TITLE
Use loop instead of with_items

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,7 +82,7 @@
     owner: "{{ homebrew_user }}"
     group: "{{ homebrew_group }}"
   become: yes
-  with_items:
+  loop:
     - Cellar
     - Homebrew
     - Frameworks
@@ -112,7 +112,7 @@
   # Tap.
   - name: Ensure configured taps are tapped.
     homebrew_tap: "tap={{ item }} state=present"
-    with_items: "{{ homebrew_taps }}"
+    loop: "{{ homebrew_taps }}"
 
   # Cask.
   - name: Install configured cask applications.
@@ -121,13 +121,13 @@
       state: present
       install_options: "appdir={{ homebrew_cask_appdir }}"
       accept_external_apps: "{{ homebrew_cask_accept_external_apps }}"
-    with_items: "{{ homebrew_cask_apps }}"
+    loop: "{{ homebrew_cask_apps }}"
     notify:
       - Clear homebrew cache
 
   - name: Ensure blacklisted cask applications are not installed.
     homebrew_cask: "name={{ item }} state=absent"
-    with_items: "{{ homebrew_cask_uninstalled_apps }}"
+    loop: "{{ homebrew_cask_uninstalled_apps }}"
 
   # Brew.
   - name: Ensure configured homebrew packages are installed.
@@ -135,13 +135,13 @@
       name: "{{ item.name | default(item) }}"
       install_options: "{{ item.install_options | default(omit) }}"
       state: present
-    with_items: "{{ homebrew_installed_packages }}"
+    loop: "{{ homebrew_installed_packages }}"
     notify:
       - Clear homebrew cache
 
   - name: Ensure blacklisted homebrew packages are not installed.
     homebrew: "name={{ item }} state=absent"
-    with_items: "{{ homebrew_uninstalled_packages }}"
+    loop: "{{ homebrew_uninstalled_packages }}"
 
   - name: Upgrade all homebrew packages (if configured).
     homebrew: update_homebrew=yes upgrade_all=yes


### PR DESCRIPTION
Looping syntax is changing and so this change updates how looping
is peformed for future compatibility.

Since the `squash_actions` behavior in `with_X` loops has been
deprecated and will be removed in Ansible 2.11, there continues to
be noisy deprecation warnings. This persists even when attempting to
override the `squash_actions` setting to remove the `homebrew` module
from the [default list][default-squash-actions].

Fixes #110

[default-squash-actions]: https://docs.ansible.com/ansible/2.7/reference_appendices/config.html?highlight=squash_actions#default-squash-actions