### PR TITLE
DRY up privilege escalation settings

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,5 @@
     path: "{{ homebrew_cache_path.stdout | trim }}"
     state: absent
   when: 'homebrew_clear_cache | bool'
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,78 +98,68 @@
     - share/zsh/site-functions
     - var
 
-- name: Force update brew after installation.
-  command: "{{ homebrew_brew_bin_path }}/brew update --force"
-  when: not homebrew_binary.stat.exists
-  become: yes
-  become_user: "{{ homebrew_user }}"
+- block:
+  - name: Force update brew after installation.
+    command: "{{ homebrew_brew_bin_path }}/brew update --force"
+    when: not homebrew_binary.stat.exists
 
-- name: Where is the cache?
-  command: "{{ homebrew_brew_bin_path }}/brew --cache"
-  register: homebrew_cache_path
-  changed_when: false
-  check_mode: no
+  - name: Where is the cache?
+    command: "{{ homebrew_brew_bin_path }}/brew --cache"
+    register: homebrew_cache_path
+    changed_when: false
+    check_mode: no
 
-# Tap.
-- name: Ensure configured taps are tapped.
-  homebrew_tap: "tap={{ item }} state=present"
-  with_items: "{{ homebrew_taps }}"
-  become: yes
-  become_user: "{{ homebrew_user }}"
+  # Tap.
+  - name: Ensure configured taps are tapped.
+    homebrew_tap: "tap={{ item }} state=present"
+    with_items: "{{ homebrew_taps }}"
 
-# Cask.
-- name: Install configured cask applications.
-  homebrew_cask:
-    name: "{{ item }}"
-    state: present
-    install_options: "appdir={{ homebrew_cask_appdir }}"
-    accept_external_apps: "{{ homebrew_cask_accept_external_apps }}"
-  with_items: "{{ homebrew_cask_apps }}"
-  notify:
-    - Clear homebrew cache
-  become: yes
-  become_user: "{{ homebrew_user }}"
+  # Cask.
+  - name: Install configured cask applications.
+    homebrew_cask:
+      name: "{{ item }}"
+      state: present
+      install_options: "appdir={{ homebrew_cask_appdir }}"
+      accept_external_apps: "{{ homebrew_cask_accept_external_apps }}"
+    with_items: "{{ homebrew_cask_apps }}"
+    notify:
+      - Clear homebrew cache
 
-- name: Ensure blacklisted cask applications are not installed.
-  homebrew_cask: "name={{ item }} state=absent"
-  with_items: "{{ homebrew_cask_uninstalled_apps }}"
-  become: yes
-  become_user: "{{ homebrew_user }}"
+  - name: Ensure blacklisted cask applications are not installed.
+    homebrew_cask: "name={{ item }} state=absent"
+    with_items: "{{ homebrew_cask_uninstalled_apps }}"
 
-# Brew.
-- name: Ensure configured homebrew packages are installed.
-  homebrew:
-    name: "{{ item.name | default(item) }}"
-    install_options: "{{ item.install_options | default(omit) }}"
-    state: present
-  with_items: "{{ homebrew_installed_packages }}"
-  notify:
-    - Clear homebrew cache
-  become: yes
-  become_user: "{{ homebrew_user }}"
+  # Brew.
+  - name: Ensure configured homebrew packages are installed.
+    homebrew:
+      name: "{{ item.name | default(item) }}"
+      install_options: "{{ item.install_options | default(omit) }}"
+      state: present
+    with_items: "{{ homebrew_installed_packages }}"
+    notify:
+      - Clear homebrew cache
 
-- name: Ensure blacklisted homebrew packages are not installed.
-  homebrew: "name={{ item }} state=absent"
-  with_items: "{{ homebrew_uninstalled_packages }}"
-  become: yes
-  become_user: "{{ homebrew_user }}"
+  - name: Ensure blacklisted homebrew packages are not installed.
+    homebrew: "name={{ item }} state=absent"
+    with_items: "{{ homebrew_uninstalled_packages }}"
 
-- name: Upgrade all homebrew packages (if configured).
-  homebrew: update_homebrew=yes upgrade_all=yes
-  when: homebrew_upgrade_all_packages
-  notify:
-    - Clear homebrew cache
-  become: yes
-  become_user: "{{ homebrew_user }}"
+  - name: Upgrade all homebrew packages (if configured).
+    homebrew: update_homebrew=yes upgrade_all=yes
+    when: homebrew_upgrade_all_packages
+    notify:
+      - Clear homebrew cache
 
-- name: Check for Brewfile.
-  stat:
-    path: "{{ homebrew_brewfile_dir }}/Brewfile"
-  register: homebrew_brewfile
-  check_mode: no
+  - name: Check for Brewfile.
+    stat:
+      path: "{{ homebrew_brewfile_dir }}/Brewfile"
+    register: homebrew_brewfile
+    check_mode: no
 
-- name: Install from Brewfile.
-  command: "brew bundle chdir={{ homebrew_brewfile_dir }}"
-  when: homebrew_brewfile.stat.exists and homebrew_use_brewfile
-  become: yes
+  - name: Install from Brewfile.
+    command: "brew bundle chdir={{ homebrew_brewfile_dir }}"
+    when: homebrew_brewfile.stat.exists and homebrew_use_brewfile
+
+  # Privilege escalation is only required for inner steps when
+  # the `homebrew_user` doesn't match the `ansible_user_id`
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
   become_user: "{{ homebrew_user }}"


### PR DESCRIPTION
This is a follow up for PR #111.

To avoid repetitious settings, this change moves several tasks
with identical privilege escalation settings (i.e. `become*`) into
a `block` structure.

Furthermore, privilege escalation need only be invoked if the
`homebrew_user` and `ansible_user_id` are mismatched, so this change
avoids unnecessary requests for privilege (e.g. `sudo -u`). In fact,
this helps preserve the original behavior prior to #111.

Finally, this change updates the handlers to run as the intended user.