### PR TITLE
Support for Custom Taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Whether to upgrade homebrew and all packages installed by homebrew. If you prefe
 
     homebrew_taps:
       - homebrew/cask
+      - { name: my_company/internal_tap, url: 'https://example.com/path/to/tap.git' }
 
 Taps you would like to make sure Homebrew has tapped.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,7 +111,10 @@
 
   # Tap.
   - name: Ensure configured taps are tapped.
-    homebrew_tap: "tap={{ item }} state=present"
+    homebrew_tap:
+      tap: '{{ item.name | default(item) }}'
+      url: '{{ item.url | default(omit) }}'
+      state: present
     loop: "{{ homebrew_taps }}"
 
   # Cask.

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,9 +3,13 @@
   vars:
     homebrew_clear_cache: true
     homebrew_installed_packages:
-      - ssh-copy-id
+      - ssh-copy-id  # from homebrew/core
+      - nginx-full  # from dengi/nginx
     homebrew_cask_apps:
-      - firefox
+      - firefox  # from hombrew/cask
+    homebrew_taps:
+      - homebrew/cask
+      - { name: denji/nginx, url: 'https://github.com/denji/homebrew-nginx.git' }
   roles:
     - elliotweiser.osx-command-line-tools
     - ansible-role-homebrew


### PR DESCRIPTION
The `homebrew_tap` module already supports pointing to a
non-github tap repository (by URL). This change adds support at
the role-level.

Fixes #90