### PR TITLE
Fix: ability to recover after messing with permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     group: "{{ homebrew_group }}"
     state: directory
     mode: 0775
+    recurse: yes
   become: yes
 
 # Clone Homebrew.
@@ -81,6 +82,7 @@
     state: directory
     owner: "{{ homebrew_user }}"
     group: "{{ homebrew_group }}"
+    recurse: yes
   become: yes
   loop:
     - Cellar


### PR DESCRIPTION
Hi Jeff, 
I have a proposal to set permissions for `homebrew_install_path` and `homebrew_prefix` recursively.

Some history:
I messed with permissions in a first try (installed everything from root instead of mac user) and got this error:
```
Failed to connect to the host via ssh:
failed: [MAC_SRV_01] (item=homebrew/core) => {
    "ansible_loop_var": "item",
    "changed": false,
    "invocation": {
        "module_args": {
            "name": [
                "homebrew/core"
            ],
            "state": "present",
            "tap": "homebrew/core",
            "url": null
        }
    },
    "item": "homebrew/core",
    "msg": "added: 0, unchanged: 0, error: failed to tap: homebrew/core"
}
```

The error message didn't show true issue at all, but after investigation I'd found that there are problems with nested permissions. So I've added recursive and issue was gone .

Could you please review this PR, maybe there is some problems with setting permissions recursively? 
