### PR TITLE
Ensure share/man/* and share/info folders are in place

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,6 +94,16 @@
     - opt
     - sbin
     - share
+    - share/info
+    - share/man
+    - share/man/man1
+    - share/man/man2
+    - share/man/man3
+    - share/man/man4
+    - share/man/man5
+    - share/man/man6
+    - share/man/man7
+    - share/man/man8
     - share/zsh
     - share/zsh/site-functions
     - var


### PR DESCRIPTION
In the light of #123 and issues I personally had with missing permissions for `share/man8`, I propose extending the list of folders for which permissions are ensured.