### PR TITLE
Update role to retry 'failed' brew cask installs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,6 +117,9 @@
     loop: "{{ homebrew_cask_apps }}"
     notify:
       - Clear homebrew cache
+    register: install_package
+    until: install_package is not failed
+    retries: 3
 
   # Brew.
   - name: Ensure blacklisted homebrew packages are not installed.


### PR DESCRIPTION
Added 3 retries to the installation of Homebrew casks.

I've been using this role to install quite a number of apps via brew cask... however I've been suffering from a number of failures causing my entire run to fail. When I've re-run the playbook, it's successfully downloaded so I don't think there is an underlying issue with the cask, it's just possibly a transient network issue.

Adding a small number of retries will improve the success rate.