### PR TITLE
Update Local Testing README with Valid Command

### DIFF
--- a/tests/local-testing/README.md
+++ b/tests/local-testing/README.md
@@ -2,7 +2,7 @@
 
 To test this Ansible Role's functionality locally, run the playbook included in this subdirectory using the following command:
 
-    ansible-playbook playbook.yml --connection=local --ask-sudo-pass
+    ansible-playbook playbook.yml --connection=local --ask-become-pass
 
 Note: This presumes you've already installed Ansible using some other method besides `brew install ansible` :)
 


### PR DESCRIPTION
Update the documentation as `--ask-sudo-pass` has been deprecated and replaced with `--ask-become-pass`.

This update will hopefully prevent future confusion, like #96.

https://github.com/ansible/ansible/commit/445ff39f944f45492bf7b2360d99fdadc02d142b#diff-c7050c69ad5b0fd2fb7eae52b4e09ea9

