### PR TITLE
Add support for external files to load taps, casks and packages lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ The path where Homebrew will be installed (`homebrew_prefix` is the parent direc
 
 The path where `brew` will be installed.
 
+    homebrew_installed_packages_list_file: "files/installed-packages-list.txt"
+
+The file contains a simple list of packages names. It is not mandatory.
+
+    # Get the list of your currently installed packages
+    brew list | grep '^[0-9]' -v > installed-packages-list.txt
+
+    cat installed-packages-list.txt
+    ansible-lint
+    curl
+    ...
+
+The list of packages contained in the list file will be merged without duplicates to the list contained in `homebrew_installed_packages`
+
     homebrew_installed_packages:
       - ssh-copy-id
       - pv
@@ -43,11 +57,41 @@ Packages you would like to make sure are _uninstalled_.
 
 Whether to upgrade homebrew and all packages installed by homebrew. If you prefer to manually update packages via `brew` commands, leave this set to `no`.
 
+    homebrew_taps_list_file: "files/taps-list.txt"
+
+The file contains a simple list of taps names. It is not mandatory.
+
+    #Get the list of your currently tapped taps
+    brew tap-info --installed | grep -v -e '^$' | grep -v 'From\|files' | cut -d: -f1 > taps-list.txt
+
+    cat taps-list.txt
+    chef/chef
+    homebrew/cask
+    homebrew/core
+    ...
+
+The list of taps contained in the list file will be merged without duplicates to the list contained in `homebrew_taps`
+
     homebrew_taps:
       - homebrew/core
       - { name: my_company/internal_tap, url: 'https://example.com/path/to/tap.git' }
 
 Taps you would like to make sure Homebrew has tapped.
+
+    homebrew_cask_apps_list_file: "files/installed-casks-list.txt"
+
+The file contains a simple list of casks names. It is not mandatory.
+
+    # Get the list of your currently installed casks
+    brew cask list | grep '^[0-9]' -v > installed-casks-list.txt
+ installed-casks-list.txt
+
+    cat installed-casks-list.txt
+    bitwarden
+    caffeine
+    ...
+
+The list of casks contained in the list file will be merged without duplicates to the list contained in `homebrew_cask_apps`
 
     homebrew_cask_apps:
       - firefox

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,14 +5,20 @@ homebrew_prefix: /usr/local
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
 
+homebrew_installed_packages_list_file: ''
+
 homebrew_installed_packages: []
 
 homebrew_uninstalled_packages: []
 
 homebrew_upgrade_all_packages: no
 
+homebrew_taps_list_file: ''
+
 homebrew_taps:
   - homebrew/core
+
+homebrew_cask_apps_list_file: ''
 
 homebrew_cask_apps: []
 

--- a/tasks/load-casks-list.yml
+++ b/tasks/load-casks-list.yml
@@ -1,0 +1,14 @@
+---
+- name: Create the list of desired Cask apps.
+  set_fact:
+    homebrew_cask_apps: "{{ homebrew_cask_apps |default([]) }} + [ '{{ item }}' ]"
+  with_lines: cat {{ homebrew_cask_apps_list_file }}
+  ignore_errors: yes
+  delegate_to: localhost
+
+- name: Remove duplicates of desired Cask apps.
+  set_fact:
+    homebrew_cask_apps: "{{ homebrew_cask_apps | unique | list }}"
+  ignore_errors: yes
+  delegate_to: localhost
+...

--- a/tasks/load-casks-list.yml
+++ b/tasks/load-casks-list.yml
@@ -1,14 +1,20 @@
 ---
-- name: Add casks from '{{ homebrew_cask_apps_list_file }}' to the list of desired Cask apps.
-  set_fact:
-    homebrew_cask_apps: "{{ homebrew_cask_apps |default([]) }} + [ '{{ item }}' ]"
-  with_lines: cat {{ homebrew_cask_apps_list_file }}
-  ignore_errors: yes
-  delegate_to: localhost
+- name: Check if '{{ homebrew_cask_apps_list_file }}' exists.
+  stat:
+    path: "{{ homebrew_cask_apps_list_file }}"
+  register: cask_apps_list_file
+  check_mode: no
 
-- name: Remove duplicates of desired Cask apps.
-  set_fact:
-    homebrew_cask_apps: "{{ homebrew_cask_apps | unique | list }}"
+- block:
+  - name: Add casks from '{{ homebrew_cask_apps_list_file }}' to the list of desired Cask apps.
+    set_fact:
+      homebrew_cask_apps: "{{ homebrew_cask_apps |default([]) }} + [ '{{ item }}' ]"
+    with_lines: cat {{ homebrew_cask_apps_list_file }}
+
+  - name: Remove duplicates of desired Cask apps.
+    set_fact:
+      homebrew_cask_apps: "{{ homebrew_cask_apps | unique | list }}"
+  when: cask_apps_list_file.stat.exists
   ignore_errors: yes
   delegate_to: localhost
 ...

--- a/tasks/load-casks-list.yml
+++ b/tasks/load-casks-list.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create the list of desired Cask apps.
+- name: Add casks from '{{ homebrew_cask_apps_list_file }}' to the list of desired Cask apps.
   set_fact:
     homebrew_cask_apps: "{{ homebrew_cask_apps |default([]) }} + [ '{{ item }}' ]"
   with_lines: cat {{ homebrew_cask_apps_list_file }}

--- a/tasks/load-packages-list.yml
+++ b/tasks/load-packages-list.yml
@@ -1,14 +1,20 @@
 ---
-- name: Add packages from '{{ homebrew_installed_packages_list_file }}' to the list of desired packages.
-  set_fact:
-    homebrew_installed_packages: "{{ homebrew_installed_packages |default([]) }} + [ '{{ item }}' ]"
-  with_lines: cat {{ homebrew_installed_packages_list_file }}
-  ignore_errors: yes
-  delegate_to: localhost
+- name: Check if '{{ homebrew_installed_packages_list_file }}' exists.
+  stat:
+    path: "{{ homebrew_installed_packages_list_file }}"
+  register: installed_packages_list_file
+  check_mode: no
 
-- name: Remove duplicates of desired packages.
-  set_fact:
-    homebrew_installed_packages: "{{ homebrew_installed_packages | unique | list }}"
+- block:
+  - name: Add packages from '{{ homebrew_installed_packages_list_file }}' to the list of desired packages.
+    set_fact:
+      homebrew_installed_packages: "{{ homebrew_installed_packages |default([]) }} + [ '{{ item }}' ]"
+    with_lines: cat {{ homebrew_installed_packages_list_file }}
+
+  - name: Remove duplicates of desired packages.
+    set_fact:
+      homebrew_installed_packages: "{{ homebrew_installed_packages | unique | list }}"
+  when: installed_packages_list_file.stat.exists
   ignore_errors: yes
   delegate_to: localhost
 ...

--- a/tasks/load-packages-list.yml
+++ b/tasks/load-packages-list.yml
@@ -1,0 +1,14 @@
+---
+- name: Create the list of desired packages.
+  set_fact:
+    homebrew_installed_packages: "{{ homebrew_installed_packages |default([]) }} + [ '{{ item }}' ]"
+  with_lines: cat {{ homebrew_installed_packages_list_file }}
+  ignore_errors: yes
+  delegate_to: localhost
+
+- name: Remove duplicates of desired packages.
+  set_fact:
+    homebrew_installed_packages: "{{ homebrew_installed_packages | unique | list }}"
+  ignore_errors: yes
+  delegate_to: localhost
+...

--- a/tasks/load-packages-list.yml
+++ b/tasks/load-packages-list.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create the list of desired packages.
+- name: Add packages from '{{ homebrew_installed_packages_list_file }}' to the list of desired packages.
   set_fact:
     homebrew_installed_packages: "{{ homebrew_installed_packages |default([]) }} + [ '{{ item }}' ]"
   with_lines: cat {{ homebrew_installed_packages_list_file }}

--- a/tasks/load-taps-list.yml
+++ b/tasks/load-taps-list.yml
@@ -1,14 +1,20 @@
 ---
-- name: Add taps from '{{ homebrew_taps_list_file }}' to the list of desired taps.
-  set_fact:
-    homebrew_taps: "{{ homebrew_taps |default([]) }} + [ '{{ item }}' ]"
-  with_lines: cat {{ homebrew_taps_list_file }}
-  ignore_errors: yes
-  delegate_to: localhost
+- name: Check if '{{ homebrew_taps_list_file }}' exists.
+  stat:
+    path: "{{ homebrew_taps_list_file }}"
+  register: taps_list_file
+  check_mode: no
 
-- name: Remove duplicates of desired taps.
-  set_fact:
-    homebrew_taps: "{{ homebrew_taps | unique | list }}"
+- block:
+  - name: Add taps from '{{ homebrew_taps_list_file }}' to the list of desired taps.
+    set_fact:
+      homebrew_taps: "{{ homebrew_taps |default([]) }} + [ '{{ item }}' ]"
+    with_lines: cat {{ homebrew_taps_list_file }}
+
+  - name: Remove duplicates of desired taps.
+    set_fact:
+      homebrew_taps: "{{ homebrew_taps | unique | list }}"
+  when: taps_list_file.stat.exists
   ignore_errors: yes
   delegate_to: localhost
 ...

--- a/tasks/load-taps-list.yml
+++ b/tasks/load-taps-list.yml
@@ -1,0 +1,14 @@
+---
+- name: Create the list of desired taps.
+  set_fact:
+    homebrew_taps: "{{ homebrew_taps |default([]) }} + [ '{{ item }}' ]"
+  with_lines: cat {{ homebrew_taps_list_file }}
+  ignore_errors: yes
+  delegate_to: localhost
+
+- name: Remove duplicates of desired taps.
+  set_fact:
+    homebrew_taps: "{{ homebrew_taps | unique | list }}"
+  ignore_errors: yes
+  delegate_to: localhost
+...

--- a/tasks/load-taps-list.yml
+++ b/tasks/load-taps-list.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create the list of desired taps.
+- name: Add taps from '{{ homebrew_taps_list_file }}' to the list of desired taps.
   set_fact:
     homebrew_taps: "{{ homebrew_taps |default([]) }} + [ '{{ item }}' ]"
   with_lines: cat {{ homebrew_taps_list_file }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,7 +108,7 @@
 
   # Cask.
   - include_tasks: load-casks-list.yml
-    when: homebrew_cask_apps_list_file is defined homebrew_taps_list_file != ''
+    when: homebrew_cask_apps_list_file is defined and homebrew_cask_apps_list_file != ''
 
   - name: Ensure blacklisted cask applications are not installed.
     homebrew_cask: "name={{ item }} state=absent"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,9 @@
     check_mode: no
 
   # Tap.
+  - include_tasks: load-taps-list.yml
+    when: homebrew_taps_list_file is defined and homebrew_taps_list_file != ''
+
   - name: Ensure configured taps are tapped.
     homebrew_tap:
       tap: '{{ item.name | default(item) }}'
@@ -104,6 +107,9 @@
     loop: "{{ homebrew_taps }}"
 
   # Cask.
+  - include_tasks: load-casks-list.yml
+    when: homebrew_cask_apps_list_file is defined homebrew_taps_list_file != ''
+
   - name: Ensure blacklisted cask applications are not installed.
     homebrew_cask: "name={{ item }} state=absent"
     loop: "{{ homebrew_cask_uninstalled_apps }}"
@@ -119,6 +125,9 @@
       - Clear homebrew cache
 
   # Brew.
+  - include_tasks: load-packages-list.yml
+    when: homebrew_installed_packages_list_file is defined and homebrew_installed_packages_list_file != ''
+
   - name: Ensure blacklisted homebrew packages are not installed.
     homebrew: "name={{ item }} state=absent"
     loop: "{{ homebrew_uninstalled_packages }}"


### PR DESCRIPTION
Allow to optionally specify file lists of taps, casks and packages.
The list loaded from the files will be merged with the lists specified as variables. The merge will eliminate duplicates.

In the README file are specified the commands to generate the lists from a pre-configured machine

This is particularly helpful if you want to build a machine as a copy of your actual machine, or if you are exporting these list regularly it will help you to build a new machine with the latest set of apps and packages of your stolen or broken machine.