### PR TITLE
Ansible2.10, Solves #153

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,6 @@
 ---
-- src: elliotweiser.osx-command-line-tools
+roles:
+  - src: elliotweiser.osx-command-line-tools
+
+collections:
+  - community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,7 +97,7 @@
 
     # Tap.
     - name: Ensure configured taps are tapped.
-      homebrew_tap:
+      community.general.homebrew_tap:
         tap: '{{ item.name | default(item) }}'
         url: '{{ item.url | default(omit) }}'
         state: present
@@ -105,11 +105,11 @@
 
     # Cask.
     - name: Ensure blacklisted cask applications are not installed.
-      homebrew_cask: "name={{ item }} state=absent"
+      community.general.homebrew_cask: "name={{ item }} state=absent"
       loop: "{{ homebrew_cask_uninstalled_apps }}"
 
     - name: Install configured cask applications.
-      homebrew_cask:
+      community.general.homebrew_cask:
         name: "{{ item.name | default(item) }}"
         state: present
         install_options: "{{ item.install_options | default('appdir=' + homebrew_cask_appdir) }}"
@@ -120,11 +120,11 @@
 
     # Brew.
     - name: Ensure blacklisted homebrew packages are not installed.
-      homebrew: "name={{ item }} state=absent"
+      community.general.homebrew: "name={{ item }} state=absent"
       loop: "{{ homebrew_uninstalled_packages }}"
 
     - name: Ensure configured homebrew packages are installed.
-      homebrew:
+      community.general.homebrew:
         name: "{{ item.name | default(item) }}"
         install_options: "{{ item.install_options | default(omit) }}"
         state: present
@@ -133,7 +133,7 @@
         - Clear homebrew cache
 
     - name: Upgrade all homebrew packages (if configured).
-      homebrew: update_homebrew=yes upgrade_all=yes
+      community.general.homebrew: update_homebrew=yes upgrade_all=yes
       when: homebrew_upgrade_all_packages
       notify:
         - Clear homebrew cache


### PR DESCRIPTION
Solves #153 

- Namespaces the `homebrew*` modules with `community.general.` - the new collection in which those modules live beginning in Ansible 2.10
- Adds the `community.general` collection to `requirements.yml`