### PR TITLE
Adjust the homebrew_prefix for M1 Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available variables are listed below, along with default values (see [`defaults/
 
 The GitHub repository for Homebrew core.
 
-    homebrew_prefix: /usr/local
+    homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
     homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 
 The path where Homebrew will be installed (`homebrew_prefix` is the parent directory). It is recommended you stick to the default, otherwise Homebrew might have some weird issues. If you change this variable, you should also manually create a symlink back to /usr/local so things work as Homebrew expects.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 homebrew_repo: https://github.com/Homebrew/brew
 
-homebrew_prefix: /usr/local
+homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
 


### PR DESCRIPTION
Fixes #156.

When we run ansible-playbook on the M1 Mac, change the `homebrew_prefix` value to `/opt/homebrew`.

### References

- [Installation — Homebrew Documentation](https://docs.brew.sh/Installation)
- [apple m1 - What is the difference between `ansible_architecture` and `ansible_machine` on Ansible? - Stack Overflow](https://stackoverflow.com/questions/66828315/what-is-the-difference-between-ansible-architecture-and-ansible-machine-on-a)